### PR TITLE
#10 fix deprecated send

### DIFF
--- a/app/server.js
+++ b/app/server.js
@@ -20,7 +20,7 @@ const endpoints = [100,101,102,
 
 endpoints.forEach(function(endpoint) {
 	app.get('/'+endpoint,function(req,res){
-		res.status(endpoint).send(endpoint);
+		res.sendStatus(endpoint);
 	});
 });
 


### PR DESCRIPTION
Fix deprecated `.send` and use `.sendStatus` instead
This removes the deprecated warning - see tests logs